### PR TITLE
Configure path aliases and API URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://dadinho-api.onrender.com

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,16 +1,16 @@
 import { Routes, Route } from "react-router-dom";
 
-import AppLayout from "./layouts/app";
-import { PATHS } from "./constants/Path";
-import { adminVerify } from "./apis/utilsStorage";
+import AppLayout from "@layouts/app";
+import { PATHS } from "@constants/Path";
+import { adminVerify } from "@apis/utilsStorage";
 
-import { LoginPage, LevelsPage, LevelPage as UserLevelsPage, AnswerPage, ConfigPage, GameInstructionsPage } from "./pages";
-import { DataPage, LevelDetailsConfigPage, LevelsPage as AdminLevelsPage, UsersPage, AdminConfigPage } from "./pages/admin";
-import AccessInstructionsPage from "./pages/accessInstructions";
-import { MapLayout } from "./layouts/map";
-import CommonLayout from "./layouts/common";
-import AdminLayout from "./layouts/admin";
-import UserLayout from "./layouts/user/UserLayout";
+import { LoginPage, LevelsPage, LevelPage as UserLevelsPage, AnswerPage, ConfigPage, GameInstructionsPage } from "@pages";
+import { DataPage, LevelDetailsConfigPage, LevelsPage as AdminLevelsPage, UsersPage, AdminConfigPage } from "@pages/admin";
+import AccessInstructionsPage from "@pages/accessInstructions";
+import { MapLayout } from "@layouts/map";
+import CommonLayout from "@layouts/common";
+import AdminLayout from "@layouts/admin";
+import UserLayout from "@layouts/user/UserLayout";
 
 const AppRoutes = () => {
   const isAdmin = adminVerify();

--- a/src/apis/base.ts
+++ b/src/apis/base.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { responseSuccessCallback, responseFailCallback, requestSuccessCallback, requestFailCallback } from "./utilService";
 
 const baseService = axios.create({
-    baseURL: "https://dadinho-api.onrender.com",
+    baseURL: process.env.REACT_APP_API_URL || "https://dadinho-api.onrender.com",
 });
 
 baseService.defaults.headers.common["Content-Type"] = "application/json";

--- a/src/apis/basket/basketService.ts
+++ b/src/apis/basket/basketService.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import baseService from "../base";
+import baseService from "@apis/base";
 
 export interface BasketPayload {
 	itemsIds: number[],

--- a/src/apis/class/classService.ts
+++ b/src/apis/class/classService.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import baseService from "../base";
+import baseService from "@apis/base";
 
 export interface AddClassPayload {
 	name: string,

--- a/src/apis/items/itemsService.ts
+++ b/src/apis/items/itemsService.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import baseService from "../base";
+import baseService from "@apis/base";
 
 export interface ItemPayload {
   icon: string;

--- a/src/apis/level/levelService.ts
+++ b/src/apis/level/levelService.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import baseService from "../base";
+import baseService from "@apis/base";
 
 export interface RecipeProps {
   id: string;

--- a/src/apis/levels/levelsService.ts
+++ b/src/apis/levels/levelsService.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import baseService from "../base";
+import baseService from "@apis/base";
 
 export interface LevelsPayload {
   id: string;

--- a/src/apis/login/loginService.ts
+++ b/src/apis/login/loginService.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import baseService from "../base";
+import baseService from "@apis/base";
 
 export interface LoginPayload {
   email: string;

--- a/src/apis/recipe/recipeService.ts
+++ b/src/apis/recipe/recipeService.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import baseService from "../base";
+import baseService from "@apis/base";
 
 export interface RecipePayload {
 	itemId: number,

--- a/src/apis/user/userService.ts
+++ b/src/apis/user/userService.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import baseService from "../base";
+import baseService from "@apis/base";
 
 export interface AddUserPayload {
   name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,19 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "src",
+    "paths": {
+      "@pages/*": ["pages/*"],
+      "@pages": ["pages/index"],
+      "@components/*": ["components/*"],
+      "@components": ["components/index"],
+      "@utils/*": ["utils/*"],
+      "@layouts/*": ["layouts/*"],
+      "@constants/*": ["constants/*"],
+      "@icons/*": ["icons/*"],
+      "@apis/*": ["apis/*"]
+    }
   },
   "include": [
     "src"


### PR DESCRIPTION
## Summary
- shorten import paths using `paths` mapping in `tsconfig.json`
- use `REACT_APP_API_URL` environment variable for API base url
- add `.env` with default backend link
- update imports to use new aliases

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d89972fc83288fe574496f850040