### PR TITLE
Fix dialog closing and tweak header image

### DIFF
--- a/src/pages/level/components/SubmitFeedbackDialog.tsx
+++ b/src/pages/level/components/SubmitFeedbackDialog.tsx
@@ -15,14 +15,18 @@ interface SubmitFeedbackDialogProps extends GameSubmitResponse {
   onViewErrors: () => void;
 }
 
-export const SubmitFeedbackDialog = ({ finalBasket, status, isOpen, onClose, onContinue, onViewErrors }: SubmitFeedbackDialogProps) => {
+  export const SubmitFeedbackDialog = ({ finalBasket, status, isOpen, onClose, onContinue, onViewErrors }: SubmitFeedbackDialogProps) => {
+    const handleClose = (_event: object, reason?: string) => {
+      if (reason === "backdropClick") return;
+      onClose();
+    };
     return (
         <DadinhoDialog
             disablePortal
             maxWidth="xs"
             fullWidth
             open={isOpen}
-            onClose={onClose}
+            onClose={handleClose}
             sx={{
               "> .MuiDialog-paper": {
                 border: "2px solid blacks"
@@ -36,6 +40,7 @@ export const SubmitFeedbackDialog = ({ finalBasket, status, isOpen, onClose, onC
                     backgroundSize: 'auto',
                     backgroundRepeat: 'no-repeat',
                     backgroundPosition: 'center',
+                    mt: -2,
                     mb: -7,
                     position: "relative",
                     zIndex: 10,

--- a/src/pages/level/components/SubmitIncorrectDetailsDialog.tsx
+++ b/src/pages/level/components/SubmitIncorrectDetailsDialog.tsx
@@ -23,13 +23,17 @@ export const SubmitIncorrectDetailsDialog = ({ status, expected, finalBasket, is
       navigate(PATHS.GAME_INSTRUCTIONS);
   }
 
+  const dialogClose = (_event: object, reason?: string) => {
+    if (reason === "backdropClick") return;
+    handleClose();
+  };
   return (
     <DadinhoDialog
       disablePortal
       maxWidth="xs"
       fullWidth
       open={isOpen}
-      onClose={handleClose}
+      onClose={dialogClose}
             sx={{
               border: "2px solid black",
               "> .MuiDialog-paper": {
@@ -44,6 +48,7 @@ export const SubmitIncorrectDetailsDialog = ({ status, expected, finalBasket, is
               backgroundSize: 'auto',
               backgroundRepeat: 'no-repeat',
               backgroundPosition: 'center',
+              mt: -2,
               position: "relative",
               zIndex: 10,
           }}


### PR DESCRIPTION
## Summary
- prevent SubmitFeedbackDialog from closing when clicking outside
- prevent SubmitIncorrectDetailsDialog from closing when clicking outside
- nudge header images slightly above dialog

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b51763883289f22a28349e8f042